### PR TITLE
Add support for project scoped expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ commands:
       command: "npm run build -- ${{env.PRODUCTION ? '--prod' : ''}}" # Contents of `${{}}` is evaluated as a javascript expression
   test:
     command: npm run test
-    condition: env.RUN_TESTS === 'true' # Javascript expression
+    condition: env.RUN_TESTS_FOR.split(',').includes(name) # Javascript expression
 ```
 
 ## Expressions & Templating
@@ -113,6 +113,14 @@ e.g.
 - `env.SOME_ENV_VAR`
 - `projects.MyProject.version.hash`
 - `projects['My.Project'].version.hash`
+
+Project scoped expressions (Used in `list` & `run` commands) also have access to project properties.
+
+e.g.
+
+- `name`
+- `dir`
+- `version.hash`
 
 ```typescript
 {

--- a/src/cli/ListCommand.ts
+++ b/src/cli/ListCommand.ts
@@ -28,7 +28,7 @@ export class ListCommand extends BaseProjectFilterCommand<[ProjectFilterOptions]
       .name('list')
       .description('Lists all projects within the current git repository')
       .option('--long-version', 'Show full version string')
-      .option('-t --template <template>', 'Template string to customise how each project is printed using project variables', defaultTemplate)
+      .option('--template <template>', 'Template string to customise how each project is printed using project variables', defaultTemplate)
       .option('-j --join <join>', 'String to join project templates by', EOL);
   }
 
@@ -43,6 +43,7 @@ export class ListCommand extends BaseProjectFilterCommand<[ProjectFilterOptions]
       this.error('No matching projects');
     }
 
+    await this.evalService.prepareContext();
     const templated = projects.map(project => this.evalService.safeEvalTemplate(options.template, {
       longVersion: options.longVersion,
       ...project,

--- a/src/cli/RunCommand.ts
+++ b/src/cli/RunCommand.ts
@@ -178,7 +178,7 @@ export class RunCommand extends BaseProjectFilterCommand<[string, RunCommandOpti
     let reason = 'evaluated to false';
 
     try {
-      result = !!this.evalService.safeEval(projectCommand.condition);
+      result = !!this.evalService.safeEval(projectCommand.condition, project);
     } catch (err) {
       result = false;
       reason = `failed to evaluate '${err}'`;
@@ -209,7 +209,7 @@ export class RunCommand extends BaseProjectFilterCommand<[string, RunCommandOpti
 
       this.updateProjectStatus(project, ProjectCommandStatus.running, commandName);
 
-      const command = this.evalService.safeEvalTemplate(projectCommand.command);
+      const command = this.evalService.safeEvalTemplate(projectCommand.command, project);
       const commandArguments = projectCommand.arguments?.map(arg => this.evalService.safeEvalTemplate(arg));
 
       const commandProcess = this.spawnService.spawn(command, commandArguments ?? [], {

--- a/src/util/EvalService.ts
+++ b/src/util/EvalService.ts
@@ -24,6 +24,7 @@ export interface EvalService {
   /**
    * Evaluates all code blocks in the provided template
    * @param template
+   * @param context Additional context values to include
    * @returns The processed template
    */
   safeEvalTemplate(template: string, context?: object): string;
@@ -31,8 +32,9 @@ export interface EvalService {
   /**
    * Evaluates the provided code using a generated context
    * @param code The code to evaluate
+   * @param context Additional context values to include
    */
-  safeEval(code: string): unknown;
+  safeEval(code: string, context?: object): unknown;
 }
 
 export interface EvalContextFixed {
@@ -95,7 +97,10 @@ export class EvalServiceImpl implements EvalService {
   }
 
   safeEval(code: string, context?: object): unknown {
-    return safeEval(code, context ?? this.context);
+    return safeEval(code, {
+      ...this.context,
+      ...context,
+    });
   }
 
   async buildContext(): Promise<EvalContext> {

--- a/test/cli/RunCommand.spec.ts
+++ b/test/cli/RunCommand.spec.ts
@@ -86,23 +86,31 @@ describe('RunCommand', () => {
         '[Project1] success: Command `echo error>&2` completed'
       ]));
 
-    test('when running command with template expression should execute replacement',
-      () => testHelper.testParse(['contextCommand', '-c', 'echo=This is from the context'], [
-        '[Project1] running: `echo ${{context.echo}}`',
-        '[Project1] This is from the context',
-        '[Project1] success: Command `echo ${{context.echo}}` completed',
-      ])
-    );
+    describe('when running command with template expression', () => {
+      test('when running command with template expression should execute replacement',
+        () => testHelper.testParse(['contextCommand', '-c', 'echo=This is from the context'], [
+          '[Project1] running: `echo ${{context.echo}}`',
+          '[Project1] This is from the context',
+          '[Project1] success: Command `echo ${{context.echo}}` completed',
+        ])
+      );
 
+      test('when running command with template expression should execute replacement',
+        () => testHelper.testParse(['contextCommandArg', '-c', 'echo=This is from the context'], [
+          '[Project1] running: `echo "${{context.echo}}"`',
+          '[Project1] This is from the context',
+          '[Project1] success: Command `echo "${{context.echo}}"` completed',
+        ])
+      );
 
-
-    test('when running command with template expression should execute replacement',
-      () => testHelper.testParse(['contextCommandArg', '-c', 'echo=This is from the context'], [
-        '[Project1] running: `echo "${{context.echo}}"`',
-        '[Project1] This is from the context',
-        '[Project1] success: Command `echo "${{context.echo}}"` completed',
-      ])
-    );
+      test('which is project scoped should execute replacement',
+        () => testHelper.testParse(['contextCommandProjectScoped'], [
+          '[Project1] running: `echo ${{name}}`',
+          '[Project1] Project1',
+          '[Project1] success: Command `echo ${{name}}` completed',
+        ])
+      );
+    });
 
     describe('when running failing command', () => {
       test('should exit with code 22',
@@ -129,28 +137,40 @@ describe('RunCommand', () => {
       test('that fails should skip command',
         () => testHelper.testParse(['skipCondition'], [
           '[Project1] skipped: Condition `1 === 2` evaluated to false',
-        ]));
+        ])
+      );
 
       test('that fails and fail behaviour ignoring failures should fail project command without error',
         () => testHelper.testParse(['failCondition', '--continue-on-failure'], [
           '[Project1] failed: Condition `1 === 2` evaluated to false',
-        ]));
+        ])
+      );
 
       test('using context parameter to pass should run command',
         () => testHelper.testParse(['contextCondition', '--context', 'val=1'], [
           '[Project1] running: `echo running`',
           '[Project1] running',
           '[Project1] success: Command `echo running` completed',
-        ]));
+        ])
+      );
       test('using context parameter to skip should skip command',
         () => testHelper.testParse(['contextCondition', '--context', 'val=2'], [
           '[Project1] skipped: Condition `1 == context.val` evaluated to false',
-        ]));
+        ])
+      );
+      test('using project scoped expression to pass should run command',
+        () => testHelper.testParse(['contextProjectScopedCondition'], [
+          '[Project1] running: `echo running`',
+          '[Project1] running',
+          '[Project1] success: Command `echo running` completed',
+        ])
+      );
 
       test('is malformed, should skip command',
         () => testHelper.testParse(['malformedCondition'], [
           '[Project1] skipped: Condition `1 = 2` failed to evaluate \'SyntaxError: Invalid left-hand side in assignment\'',
-        ]));
+        ])
+      );
     });
 
     test('when unknown command provided should exit with code 21',

--- a/test/project-examples.ts
+++ b/test/project-examples.ts
@@ -12,51 +12,58 @@ export const projectExamples = {
       'project-type:dotnet'
     ],
     commands: {
-      test: [{
+      test: {
         command: 'echo running',
-      }],
-      project1: [{
+      },
+      project1: {
         command: 'echo running',
-      }],
-      contextCommand: [{
+      },
+      contextCommand: {
         command: 'echo ${{context.echo}}'
-      }],
-      contextCommandArg: [{
+      },
+      contextCommandArg: {
         command: 'echo',
         arguments: [
           '${{context.echo}}'
         ]
-      }],
-      fail: [{
+      },
+      contextCommandProjectScoped: {
+        command: 'echo ${{name}}',
+      },
+      fail: {
         command: 'exit 1'
-      }],
-      failSkip: [{
+      },
+      failSkip: {
         command: 'exit 42',
         failureBehavior: 'skip'
-      }],
-      failParallel: [{
+      },
+      failParallel: {
         command: 'exit 1'
-      }],
-      logError: [{
+      },
+      logError: {
         command: 'echo error>&2'
-      }],
-      skipCondition: [{
+      },
+      skipCondition: {
         command: 'exit 1',
         condition: '1 === 2',
-      }],
-      failCondition: [{
+      },
+      failCondition: {
         command: 'exit 1',
         condition: '1 === 2',
         conditionBehaviour: 'fail',
-      }],
-      contextCondition: [{
+      },
+      contextCondition: {
         command: 'echo running',
         condition: '1 == context.val',
-      }],
-      malformedCondition: [{
+      },
+      contextProjectScopedCondition: {
+        command: 'echo running',
+        condition: 'name.startsWith("Project")',
+      },
+      malformedCondition: {
         command: 'exit 42',
         condition: '1 = 2'
-      }]
+      }
     },
     version: {
       hash: 'a-long',


### PR DESCRIPTION

This support was missing in `run` command, and slightly broken in `list`.

* Update README.md
* Combine general context & project scoped context for evaluation
* Add support to `run` for project scoped expressions
