### PR TITLE
Add support for `.env` and `.[commandName].env` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,22 @@ By default, your command run's in your OS's default shell. If your command requi
 
 During exeuction, your command is provided with additional environment variables which can be used by your command or the process it executes.
 
-| Environment Variable    | Description                                                                |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `REPOSITORY_DIR`        | The base directory of the running project                                  |
-| `PROJECT_NAME`          | The name of the project                                                    |
-| `PROJECT_VERSION`       | The hash of the last commit to change this project or it's dependencies    |
-| `PROJECT_VERSION_SHORT` | Same has PROJECT_VERSION, but only the first 8 characters                  |
-| `CONTEXT_${key}`        | Every context parameter passed via CLI arguments, prefixed with `CONTEXT_` |
+| Environment Variable       | Description                                                                |
+| -------------------------- | -------------------------------------------------------------------------- |
+| `REPOSITORY_DIR`           | The base directory of the running project                                  |
+| `PROJECT_NAME`             | The name of the project                                                    |
+| `PROJECT_VERSION`          | The hash of the last commit to change this project or it's dependencies    |
+| `PROJECT_VERSION_SHORT`    | Same has PROJECT_VERSION, but only the first 8 characters                  |
+| `CONTEXT_${key.toUpper()}` | Every context parameter passed via CLI arguments, prefixed with `CONTEXT_` |
+
+You can also create `.env` and `.[commandName].env` files to specify additional environment variables to provide to your commands.
+
+`.env` files are loaded from parent directories. More specific `.env` files can override the values of less specific files.
+i.e. `.[commandName].env` files override `.env` files in the same directory, and files your project directory override any files in parent directories.
+
+`.env` and `.[commandName].env` files also support variable expansion via `dotenv-expand`.
+Variable expansion can reference any environment variable, including variables in the above table, or any variables defined in your `.env` files.
+See examples of expansion [here](https://github.com/motdotla/dotenv-expand/blob/master/tests/.env).
 
 ### Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "build-champ",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "build-champ",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chalk": "^4.1.2",
         "commander": "^9.4.1",
         "dotenv": "^16.0.3",
+        "dotenv-expand": "^10.0.0",
         "glob": "^8.0.3",
         "inversify": "^6.0.1",
         "lodash": "^4.17.21",
@@ -2280,6 +2281,14 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
       "engines": {
         "node": ">=12"
       }
@@ -7457,6 +7466,11 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+    },
+    "dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
     },
     "electron-to-chromium": {
       "version": "1.4.284",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^9.4.1",
+        "dotenv": "^16.0.3",
         "glob": "^8.0.3",
         "inversify": "^6.0.1",
         "lodash": "^4.17.21",
@@ -23,7 +24,7 @@
         "yaml": "^2.1.3"
       },
       "bin": {
-        "build-champ": "dist/index.js"
+        "build-champ": "dist/src/index.js"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.3",
@@ -2273,6 +2274,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -7443,6 +7452,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "electron-to-chromium": {
       "version": "1.4.284",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "chalk": "^4.1.2",
     "commander": "^9.4.1",
     "dotenv": "^16.0.3",
+    "dotenv-expand": "^10.0.0",
     "glob": "^8.0.3",
     "inversify": "^6.0.1",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "commander": "^9.4.1",
+    "dotenv": "^16.0.3",
     "glob": "^8.0.3",
     "inversify": "^6.0.1",
     "lodash": "^4.17.21",

--- a/src/TYPES.ts
+++ b/src/TYPES.ts
@@ -1,6 +1,7 @@
 export const singleInjectTypes = {
   BaseDir: Symbol.for('BaseDir'),
   BaseDirProvider: Symbol.for('BaseDirProvider'),
+  ContextService: Symbol.for('ContextService'),
   EvalService: Symbol.for('EvalService'),
   GitProvider: Symbol.for('GitProvider'),
   Program: Symbol.for('Program'),

--- a/src/cli/BaseProjectCommand.ts
+++ b/src/cli/BaseProjectCommand.ts
@@ -1,7 +1,6 @@
 import { Command, ErrorOptions } from 'commander';
 import { injectable } from 'inversify';
 import 'reflect-metadata';
-import { EvalContextDynamic, EvalService } from '../util/EvalService';
 
 @injectable()
 export abstract class BaseProjectCommand<TArgs extends unknown[]> {
@@ -51,17 +50,6 @@ export abstract class BaseProjectCommand<TArgs extends unknown[]> {
     } else {
       this.command.configureOutput().writeErr?.(message);
       this.command.configureOutput().writeErr?.('\n');
-    }
-  }
-
-  async prepareEvalContext(evalService: EvalService, contextValues?: `${string}=${string}`[], dynamicContext?: Partial<Omit<EvalContextDynamic, 'context'>>) {
-    await evalService.prepareContext();
-
-    if (contextValues && contextValues.length > 0) {
-      evalService.amendContext({
-        ...dynamicContext,
-        context: Object.fromEntries(contextValues.map(v => v.split('=') as [string, string])),
-      });
     }
   }
 }

--- a/src/cli/ListCommand.ts
+++ b/src/cli/ListCommand.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from 'inversify';
 import { EOL } from 'os';
+import { ContextService } from '../projects/ContextService';
 import { ProjectService } from '../projects/ProjectService';
 import { TYPES } from '../TYPES';
 import { EvalService } from '../util/EvalService';
@@ -20,6 +21,7 @@ export class ListCommand extends BaseProjectFilterCommand<[ProjectFilterOptions]
     @inject(TYPES.BaseDir) public baseDir: string,
     @inject(TYPES.ProjectService) projectService: ProjectService,
     @inject(TYPES.RepositoryService) repositoryService: RepositoryService,
+    @inject(TYPES.ContextService) private readonly contextService: ContextService,
     @inject(TYPES.EvalService) private readonly evalService: EvalService,
   ) {
     super(projectService, repositoryService);
@@ -43,11 +45,17 @@ export class ListCommand extends BaseProjectFilterCommand<[ProjectFilterOptions]
       this.error('No matching projects');
     }
 
-    await this.evalService.prepareContext();
-    const templated = projects.map(project => this.evalService.safeEvalTemplate(options.template, {
-      longVersion: options.longVersion,
-      ...project,
-    }));
+    const templated: string[] = [];
+
+    for (const project of projects) {
+      const context = await this.contextService.getProjectContext(project);
+      templated.push(
+        this.evalService.safeEvalTemplate(options.template, {
+          ...context,
+          longVersion: options.longVersion,
+        })
+      );
+    }
 
     this.log(templated.join(options.join));
   }

--- a/src/cli/ListCommand.ts
+++ b/src/cli/ListCommand.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 import { EOL } from 'os';
-import { ContextService } from '../projects/ContextService';
+import { ContextService } from '../util/ContextService';
 import { ProjectService } from '../projects/ProjectService';
 import { TYPES } from '../TYPES';
 import { EvalService } from '../util/EvalService';

--- a/src/cli/RunCommand.ts
+++ b/src/cli/RunCommand.ts
@@ -214,17 +214,7 @@ export class RunCommand extends BaseProjectFilterCommand<[string, RunCommandOpti
         signal: abortController?.signal,
         stdio: 'pipe',
         shell: projectCommand.shell ?? true,
-        env: {
-          ...context.env,
-          REPOSITORY_DIR: this.baseDir,
-          PROJECT_NAME: project.name,
-          PROJECT_VERSION: project.version.hash,
-          PROJECT_VERSION_SHORT: project.version.hashShort,
-          ...Object.fromEntries(
-            Object.entries(context.context)
-              .map(([key, value]) => [`CONTEXT_${key.toUpperCase()}`, value])
-          ),
-        }
+        env: context.env,
       });
 
       const configureOutput = (stream: typeof commandProcess.stdout, isErr: boolean) => {

--- a/src/cli/RunCommand.ts
+++ b/src/cli/RunCommand.ts
@@ -2,7 +2,7 @@ import chalk, { Chalk } from 'chalk';
 import { inject, injectable } from 'inversify';
 import PQueue from 'p-queue';
 import { resolve as resolvePath } from 'path';
-import { ContextService, ProjectContext } from '../projects/ContextService';
+import { ContextService, ProjectContext } from '../util/ContextService';
 import { Project, ProjectWithVersion } from '../projects/Project';
 import { ProjectCommand } from '../projects/ProjectCommand';
 import { ProjectCommandStatus } from '../projects/ProjectCommandStatus';

--- a/src/cli/TemplateCommand.ts
+++ b/src/cli/TemplateCommand.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
 import { inject, injectable } from 'inversify';
-import { ContextService } from '../projects/ContextService';
+import { ContextService } from '../util/ContextService';
 import { TYPES } from '../TYPES';
 import { EvalService } from '../util/EvalService';
 import { BaseProjectCommand } from './BaseProjectCommand';

--- a/src/cli/TemplateCommand.ts
+++ b/src/cli/TemplateCommand.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'fs/promises';
 import { inject, injectable } from 'inversify';
+import { ContextService } from '../projects/ContextService';
 import { TYPES } from '../TYPES';
 import { EvalService } from '../util/EvalService';
 import { BaseProjectCommand } from './BaseProjectCommand';
@@ -29,6 +30,7 @@ export interface TemplateCommandOptions {
 @injectable()
 export class TemplateCommand extends BaseProjectCommand<[TemplateCommandOptions]> {
   constructor(
+    @inject(TYPES.ContextService) private readonly contextService: ContextService,
     @inject(TYPES.EvalService) private readonly evalService: EvalService,
     @inject(TYPES.BaseDir) private readonly baseDir: string,
   ) {
@@ -48,10 +50,11 @@ export class TemplateCommand extends BaseProjectCommand<[TemplateCommandOptions]
 
     const template = await this.getTemplateContent(options);
 
-    await this.prepareEvalContext(this.evalService, options.contextValues);
+    this.contextService.parseContextParameters(options.contextValues);
+    const context = await this.contextService.getContext();
 
     this.command.configureOutput()
-      .writeOut?.(this.evalService.safeEvalTemplate(template));
+      .writeOut?.(this.evalService.safeEvalTemplate(template, context));
   }
 
   async getTemplateContent(options: TemplateCommandOptions) {

--- a/src/containerModule.ts
+++ b/src/containerModule.ts
@@ -7,7 +7,7 @@ import { InitCommand } from './cli/InitCommand';
 import { ListCommand } from './cli/ListCommand';
 import { RunCommand } from './cli/RunCommand';
 import { TemplateCommand } from './cli/TemplateCommand';
-import { ContextService, ContextServiceImpl } from './projects/ContextService';
+import { ContextService, ContextServiceImpl } from './util/ContextService';
 import { ProjectMetadataLoader } from './projects/metadata';
 import { DotnetMetadataHandler } from './projects/metadata/DotnetMetadataHandler';
 import { ProjectProcessor } from './projects/processors';

--- a/src/containerModule.ts
+++ b/src/containerModule.ts
@@ -7,6 +7,7 @@ import { InitCommand } from './cli/InitCommand';
 import { ListCommand } from './cli/ListCommand';
 import { RunCommand } from './cli/RunCommand';
 import { TemplateCommand } from './cli/TemplateCommand';
+import { ContextService, ContextServiceImpl } from './projects/ContextService';
 import { ProjectMetadataLoader } from './projects/metadata';
 import { DotnetMetadataHandler } from './projects/metadata/DotnetMetadataHandler';
 import { ProjectProcessor } from './projects/processors';
@@ -42,6 +43,7 @@ export const containerModule = new ContainerModule((bind, _, isBound) => {
       .toDynamicValue(c => c.container.get<BaseDirProvider>(TYPES.BaseDirProvider).baseDir);
   }
 
+  bind<ContextService>(TYPES.ContextService).to(ContextServiceImpl).inSingletonScope();
   bind<EvalService>(TYPES.EvalService).to(EvalServiceImpl).inSingletonScope();
   bind<GitProvider>(TYPES.GitProvider).to(GitProvider).inSingletonScope();
   bind<ProjectService>(TYPES.ProjectService).to(ProjectServiceImpl).inSingletonScope();

--- a/src/projects/ContextService.ts
+++ b/src/projects/ContextService.ts
@@ -1,0 +1,197 @@
+import { parse } from 'dotenv';
+import { readFile } from 'fs/promises';
+import { inject, injectable } from 'inversify';
+import minimatch from 'minimatch';
+import { resolve } from 'path';
+import { TYPES } from '../TYPES';
+import { globAsync } from '../util/globAsync';
+import { Project, ProjectWithVersion } from './Project';
+import { ProjectCommandStatus } from './ProjectCommandStatus';
+import { ProjectService } from './ProjectService';
+
+export interface ContextFixed {
+  readonly env: NodeJS.ProcessEnv,
+  readonly os: NodeJS.Platform,
+  readonly projects: Record<string, ProjectWithVersion>,
+  readonly ProjectCommandStatus: typeof ProjectCommandStatus;
+}
+
+export interface ContextDynamic {
+  /**
+   * Current statuses of all projects
+   */
+  readonly status: Record<string, ProjectCommandStatus>;
+
+  /**
+   * Custom context variables
+   */
+  readonly context: Record<string, string>;
+}
+
+export interface Context extends ContextFixed, ContextDynamic { }
+export type ProjectContext = Context & ProjectWithVersion;
+
+export interface ContextService {
+  /**
+   * Gets the base context
+   */
+  getContext(): Promise<Context>;
+  /**
+   * Gets a context for the provided scopes
+   * @param project Project scope
+   * @param command Command scope
+   */
+  getProjectContext(project: ProjectWithVersion, status?: string): Promise<ProjectContext>;
+
+  // getContext(project?: Project, command?: string): Promise<Context>;
+
+  getProjectStatus(project: Project): ProjectCommandStatus;
+  setProjectStatus(project: Project, status: ProjectCommandStatus): void;
+
+  parseContextParameters(values: `${string}=${string}`[]): void;
+}
+
+@injectable()
+export class ContextServiceImpl implements ContextService {
+  private context?: ContextFixed;
+
+  private readonly projectStatuses: Record<string, ProjectCommandStatus> = this.getCaseInsensitiveProxy({});
+  private readonly contextParameters: Record<string, string> = this.getCaseInsensitiveProxy({});
+
+
+  private envFiles?: string[];
+  private readonly envVars: Record<string, Record<string, string>> = {};
+
+  constructor(
+    @inject(TYPES.BaseDir) private readonly baseDir: string,
+    @inject(TYPES.ProjectService) private readonly projectService: ProjectService,
+  ) { }
+
+  async getContext(): Promise<Context> {
+    if (!this.context) {
+      this.context = await this.buildContext();
+    }
+
+    return {
+      ...this.context,
+      status: this.projectStatuses,
+      context: this.contextParameters,
+    };
+  }
+
+  async getProjectContext(project: ProjectWithVersion, command?: string): Promise<ProjectContext> {
+    const context = await this.getContext();
+
+    const envFiles = await this.getEnvFilesForProject(project, command);
+
+    // Combine environment variables, prioritizing lower hierarchies
+    const environment = await envFiles.reduce(
+      (p, f) => p.then(async env => ({ ...env, ...await this.getEnvVarsFromFile(f) })),
+      Promise.resolve({} as Record<string, string>)
+    );
+
+    return {
+      ...context,
+      env: this.getCaseInsensitiveProxy({
+        ...process.env,
+        ...environment
+      }),
+      ...project,
+    };
+  }
+
+  getProjectStatus(project: Project): ProjectCommandStatus {
+    return this.projectStatuses[project.name];
+  }
+
+  setProjectStatus(project: Project, status: ProjectCommandStatus) {
+    this.projectStatuses[project.name] = status;
+  }
+
+  parseContextParameters(values: `${string}=${string}`[]): void {
+    if (values) {
+      values.map(v => v.split('=') as [string, string])
+        .forEach(([k, v]) => this.contextParameters[k] = v);
+    }
+  }
+
+  async getEnvFiles(): Promise<string[]> {
+    if (!this.envFiles) {
+      this.envFiles = await globAsync('**/.{*.env,env}', { cwd: this.baseDir, nocase: true });
+      // Sort by hierarchy count
+      this.envFiles.sort((a, b) => Array.from(a.matchAll(/[/\\]/g)).length - Array.from(b.matchAll(/[/\\]/g)).length);
+    }
+
+    return this.envFiles;
+  }
+
+  async getEnvFilesForProject(project: Project, command?: string): Promise<string[]> {
+    const envPattern = command
+      ? `{.env,.${command}.env}`
+      : '.env';
+
+    const checkDirs = Array.from(project.dir.matchAll(/[/\\]/g))
+      .map(m => project.dir.slice(0, m.index))
+      .concat(project.dir);
+
+    const dirPattern = checkDirs.length > 1
+      ? `{${checkDirs.join(',')}}`
+      : project.dir;
+
+    const pattern = `${dirPattern}/${envPattern}`;
+    return (await this.getEnvFiles())
+      .filter(f => minimatch(f, pattern, { nocase: true }));
+  }
+
+  async getEnvVarsFromFile(envFile: string) {
+    if (this.envVars[envFile]) {
+      return this.envVars[envFile];
+    }
+    const content = await readFile(resolve(this.baseDir, envFile));
+    const envVars = parse(content);
+    this.envVars[envFile] = envVars;
+    return envVars;
+  }
+
+  async buildContext(): Promise<Context> {
+    const projectList = await this.projectService.getProjectsWithVersions();
+
+    const projects = Object.fromEntries(
+      projectList.map(p => [p.name, p])
+    );
+
+    const envFiles = await this.getEnvFiles();
+    const rootEnvFile = envFiles.find(e => e.localeCompare('.env', undefined, { sensitivity: 'base' }));
+
+    const envVars: Record<string, string | undefined> = rootEnvFile
+      ? { ...process.env, ...await this.getEnvVarsFromFile(rootEnvFile) }
+      : process.env;
+
+    return {
+      env: this.getCaseInsensitiveProxy(envVars),
+      os: process.platform,
+      projects: this.getCaseInsensitiveProxy(projects),
+      ProjectCommandStatus,
+      status: {},
+      context: {},
+    };
+  }
+
+  getCaseInsensitiveProxy<T>(target: Record<string, T>) {
+    return new Proxy(target, {
+      get(target, p) {
+        if (typeof p !== 'string') {
+          return undefined;
+        }
+        if (target[p]) {
+          return target[p];
+        }
+        for (const projectName in target) {
+          if (p.localeCompare(projectName, undefined, { sensitivity: 'base' }) === 0) {
+            return target[projectName];
+          }
+        }
+      }
+    });
+  }
+}

--- a/src/util/ContextService.ts
+++ b/src/util/ContextService.ts
@@ -152,6 +152,7 @@ export class ContextServiceImpl implements ContextService {
       ...baseEnv,
       ...Object.fromEntries(
         Object.entries(this.contextParameters)
+          .filter(([, value]) => value !== undefined)
           .map(([key, value]) => [`CONTEXT_${key.toUpperCase()}`, value])
       )
     });

--- a/src/util/ContextService.ts
+++ b/src/util/ContextService.ts
@@ -129,15 +129,16 @@ export class ContextServiceImpl implements ContextService {
       ? `{.env,.${command}.env}`
       : '.env';
 
-    const checkDirs = Array.from(dir.matchAll(/[/\\]/g))
-      .map(m => dir.slice(0, m.index))
-      .concat(dir);
+    const checkDirs = [
+      '',
+      ...Array.from(dir.matchAll(/[/\\]/g))
+        .map(m => dir.slice(0, m.index) + '/'),
+      `${dir}/`,
+    ];
 
-    const dirPattern = checkDirs.length > 1
-      ? `{${checkDirs.join(',')}}`
-      : dir;
+    const dirPattern = `{${checkDirs.join(',')}}`;
 
-    const pattern = `${dirPattern}/${envPattern}`;
+    const pattern = `${dirPattern}${envPattern}`;
     return (await this.getEnvFiles())
       .filter(f => minimatch(f, pattern, { nocase: true }));
   }

--- a/src/util/ContextService.ts
+++ b/src/util/ContextService.ts
@@ -39,6 +39,7 @@ export interface ContextService {
    * Gets the base context
    */
   getContext(): Promise<Context>;
+
   /**
    * Gets a context for the provided scopes
    * @param project Project scope
@@ -46,11 +47,23 @@ export interface ContextService {
    */
   getProjectContext(project: ProjectWithVersion, status?: string): Promise<ProjectContext>;
 
-  // getContext(project?: Project, command?: string): Promise<Context>;
-
+  /**
+   * Get current project status
+   * @param project
+   */
   getProjectStatus(project: Project): ProjectCommandStatus;
+
+  /**
+   * Set current project status
+   * @param project 
+   * @param status 
+   */
   setProjectStatus(project: Project, status: ProjectCommandStatus): void;
 
+  /**
+   * Parses and saves context parameters
+   * @param values context values from command args
+   */
   parseContextParameters(values: `${string}=${string}`[]): void;
 }
 

--- a/src/util/EvalService.ts
+++ b/src/util/EvalService.ts
@@ -1,7 +1,7 @@
 import { injectable } from 'inversify';
 import 'reflect-metadata';
 import safeEval from 'safe-eval';
-import { Context } from '../projects/ContextService';
+import { Context } from './ContextService';
 
 export interface EvalService {
   /**

--- a/src/util/EvalService.ts
+++ b/src/util/EvalService.ts
@@ -1,139 +1,33 @@
-import { inject, injectable } from 'inversify';
-import { cloneDeep } from 'lodash';
+import { injectable } from 'inversify';
 import 'reflect-metadata';
 import safeEval from 'safe-eval';
-import { ProjectWithVersion } from '../projects/Project';
-import { ProjectCommandStatus } from '../projects/ProjectCommandStatus';
-import { ProjectService } from '../projects/ProjectService';
-import { TYPES } from '../TYPES';
+import { Context } from '../projects/ContextService';
 
 export interface EvalService {
-  readonly context: EvalContext;
-
-  /**
-   * Prepares initial context
-   */
-  prepareContext(): Promise<void>;
-
-  /**
-   * Ammends existing context values
-   * @param context 
-   */
-  amendContext(context: Partial<EvalContextDynamic>): void;
-
   /**
    * Evaluates all code blocks in the provided template
    * @param template
-   * @param context Additional context values to include
+   * @param context Context values to pass to script
    * @returns The processed template
    */
-  safeEvalTemplate(template: string, context?: object): string;
+  safeEvalTemplate<T extends Context>(template: string, context: T): string;
 
   /**
    * Evaluates the provided code using a generated context
    * @param code The code to evaluate
-   * @param context Additional context values to include
+   * @param context Context values to pass to script
    */
-  safeEval(code: string, context?: object): unknown;
+  safeEval<T extends Context>(code: string, context: T): unknown;
 }
-
-export interface EvalContextFixed {
-  readonly env: NodeJS.ProcessEnv,
-  readonly os: NodeJS.Platform,
-  readonly projects: Record<string, ProjectWithVersion>,
-  readonly ProjectCommandStatus: typeof ProjectCommandStatus;
-}
-
-export interface EvalContextDynamic {
-  /**
-   * Current statuses of all projects
-   */
-  readonly status: Record<string, ProjectCommandStatus>;
-
-  /**
-   * Custom context variables
-   */
-  readonly context: Record<string, string>;
-}
-
-export interface EvalContext extends EvalContextFixed, EvalContextDynamic { }
 
 @injectable()
 export class EvalServiceImpl implements EvalService {
-  get context() {
-    if (!this._context) {
-      throw new Error('Must call .prepareContext() first');
-    }
-    return this._context;
-  }
-
-  private _context?: EvalContext;
-
-  constructor(
-    @inject(TYPES.ProjectService) private readonly projectService: ProjectService
-  ) {
-  }
-
-  async prepareContext() {
-    if (!this._context) {
-      this._context = await this.buildContext();
-    }
-  }
-
-  amendContext(context: Partial<EvalContextDynamic>) {
-    const proxies = Object.fromEntries(
-      Object.entries(cloneDeep(context))
-        .map(([k, v]) => ([k, this.getCaseInsensitiveProxy(v)]))
-    );
-    this._context = {
-      ...this.context,
-      ...proxies,
-    };
-  }
-
-  safeEvalTemplate(template: string, context?: object): string {
+  safeEvalTemplate<T extends Context>(template: string, context: T): string {
     return template.replaceAll(/\$\{\{((?:.|[\r\n])+?)\}\}/gm,
       (_, code) => `${this.safeEval(code, context)}`);
   }
 
-  safeEval(code: string, context?: object): unknown {
-    return safeEval(code, {
-      ...this.context,
-      ...context,
-    });
-  }
-
-  async buildContext(): Promise<EvalContext> {
-    const projectList = await this.projectService.getProjectsWithVersions();
-
-    const projects = Object.fromEntries(
-      projectList.map(p => [p.name, p])
-    );
-    return {
-      env: this.getCaseInsensitiveProxy(process.env),
-      os: process.platform,
-      projects: this.getCaseInsensitiveProxy(projects),
-      ProjectCommandStatus,
-      status: {},
-      context: {},
-    };
-  }
-
-  getCaseInsensitiveProxy<T>(target: Record<string, T>) {
-    return new Proxy(target, {
-      get(target, p) {
-        if (typeof p !== 'string') {
-          return undefined;
-        }
-        if (target[p]) {
-          return target[p];
-        }
-        for (const projectName in target) {
-          if (p.localeCompare(projectName, undefined, { sensitivity: 'base' }) === 0) {
-            return target[projectName];
-          }
-        }
-      }
-    });
+  safeEval<T extends Context>(code: string, context: T): unknown {
+    return safeEval(code, context);
   }
 }

--- a/test/cli/ListCommand.spec.ts
+++ b/test/cli/ListCommand.spec.ts
@@ -6,7 +6,7 @@ import { ProjectWithVersion } from '../../src/projects/Project';
 import { ProjectService } from '../../src/projects/ProjectService';
 import { TYPES } from '../../src/TYPES';
 import { RepositoryService } from '../../src/util/RepositoryService';
-import { createContainer, MockCommit, MockProjectService, MockRepositoryService } from '../mocks';
+import { createContainer, MockCommit, MockProjectService, MockRepositoryService, resetFs } from '../mocks';
 import { projectExamples } from '../project-examples';
 import { CommandTestHelper } from './CommandTestHelper';
 
@@ -64,7 +64,8 @@ describe(ListCommand, () => {
     version: commits.newProject,
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await resetFs();
     const container = createContainer();
 
     container.rebind<ProjectService>(TYPES.ProjectService).to(MockProjectService).inSingletonScope();

--- a/test/cli/RunCommand.spec.ts
+++ b/test/cli/RunCommand.spec.ts
@@ -1,6 +1,8 @@
 jest.mock('fs');
 jest.mock('fs/promises');
 
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
 import { cwd } from 'process';
 import { RunCommand } from '../../src/cli/RunCommand';
 import { ProjectService } from '../../src/projects/ProjectService';
@@ -45,30 +47,30 @@ describe('RunCommand', () => {
         () => testHelper.testParse(['test'], [
           '[Project2] running: `echo running`',
           '[Project2] running',
-          '[Project2] success: Command `echo running` completed',
+          '[Project2] success: `echo running`',
           '[Project1] running: `echo running`',
           '[Project1] running',
-          '[Project1] success: Command `echo running` completed'
+          '[Project1] success: `echo running`'
         ]));
 
       test('and concurrency should run in dependency order',
         () => testHelper.testParse(['test', '--concurrency=2'], [
           '[Project2] running: `echo running`',
           '[Project2] running',
-          '[Project2] success: Command `echo running` completed',
+          '[Project2] success: `echo running`',
           '[Project1] running: `echo running`',
           '[Project1] running',
-          '[Project1] success: Command `echo running` completed'
+          '[Project1] success: `echo running`'
         ]));
 
       test('ignoring order should run in dir order',
         () => testHelper.testParse(['test', '--ignore-dependencies'], [
           '[Project1] running: `echo running`',
           '[Project1] running',
-          '[Project1] success: Command `echo running` completed',
+          '[Project1] success: `echo running`',
           '[Project2] running: `echo running`',
           '[Project2] running',
-          '[Project2] success: Command `echo running` completed'
+          '[Project2] success: `echo running`'
         ]));
     });
 
@@ -76,14 +78,14 @@ describe('RunCommand', () => {
       () => testHelper.testParse(['project1'], [
         '[Project1] running: `echo running`',
         '[Project1] running',
-        '[Project1] success: Command `echo running` completed'
+        '[Project1] success: `echo running`'
       ]));
 
     test('when running command with stderr output should capture output',
       () => testHelper.testParse(['logError'], [
         '[Project1] running: `echo error>&2`',
         '[Project1] error',
-        '[Project1] success: Command `echo error>&2` completed'
+        '[Project1] success: `echo error>&2`'
       ]));
 
     describe('when running command with template expression', () => {
@@ -91,7 +93,7 @@ describe('RunCommand', () => {
         () => testHelper.testParse(['contextCommand', '-c', 'echo=This is from the context'], [
           '[Project1] running: `echo ${{context.echo}}`',
           '[Project1] This is from the context',
-          '[Project1] success: Command `echo ${{context.echo}}` completed',
+          '[Project1] success: `echo ${{context.echo}}`',
         ])
       );
 
@@ -99,7 +101,7 @@ describe('RunCommand', () => {
         () => testHelper.testParse(['contextCommandArg', '-c', 'echo=This is from the context'], [
           '[Project1] running: `echo "${{context.echo}}"`',
           '[Project1] This is from the context',
-          '[Project1] success: Command `echo "${{context.echo}}"` completed',
+          '[Project1] success: `echo "${{context.echo}}"`',
         ])
       );
 
@@ -107,7 +109,7 @@ describe('RunCommand', () => {
         () => testHelper.testParse(['contextCommandProjectScoped'], [
           '[Project1] running: `echo ${{name}}`',
           '[Project1] Project1',
-          '[Project1] success: Command `echo ${{name}}` completed',
+          '[Project1] success: `echo ${{name}}`',
         ])
       );
     });
@@ -119,15 +121,15 @@ describe('RunCommand', () => {
       test('with failureCondition = \'skip\', should skip command',
         () => testHelper.testParse(['failSkip'], [
           '[Project1] running: `exit 42`',
-          '[Project1] skipped: Command `exit 42` failed with code 42',
+          '[Project1] skipped: `exit 42` failed with code 42',
         ]));
 
       test('should cancel parallel commands', () => {
         return testHelper.testParse(['failParallel', '--concurrency=2'], [
           '[Project1] running: `exit 1`',
           '[Project3] running: `sleep 1`',
-          '[Project1] failed: Command `exit 1` failed with code 1',
-          '[Project3] failed: Command `sleep 1` cancelled',
+          '[Project1] failed: `exit 1` failed with code 1',
+          '[Project3] failed: `sleep 1` AbortError: The operation was aborted',
           'Command `failParallel` failed',
         ], { ignoreErrors: true });
       });
@@ -150,7 +152,7 @@ describe('RunCommand', () => {
         () => testHelper.testParse(['contextCondition', '--context', 'val=1'], [
           '[Project1] running: `echo running`',
           '[Project1] running',
-          '[Project1] success: Command `echo running` completed',
+          '[Project1] success: `echo running`',
         ])
       );
       test('using context parameter to skip should skip command',
@@ -162,7 +164,7 @@ describe('RunCommand', () => {
         () => testHelper.testParse(['contextProjectScopedCondition'], [
           '[Project1] running: `echo running`',
           '[Project1] running',
-          '[Project1] success: Command `echo running` completed',
+          '[Project1] success: `echo running`',
         ])
       );
 
@@ -171,6 +173,37 @@ describe('RunCommand', () => {
           '[Project1] skipped: Condition `1 = 2` failed to evaluate \'SyntaxError: Invalid left-hand side in assignment\'',
         ])
       );
+    });
+
+    test('when .env file exists, should add environment variable', async () => {
+      // Given
+      const projectDir = join('/', projectExamples.project1.dir);
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(join(projectDir, '.env'), 'DOTENV_VAR=from-dot-env');
+
+      // When/Verify
+      await testHelper.testParse(['dotEnvCommand'], [
+        '[Project1] running: echo $DOTENV_VAR',
+        '[Project1] from-dot-env',
+        '[Project1] success: echo $DOTENV_VAR'
+      ]);
+    });
+
+
+
+    test('when multiple .env file exists, should use value from closest scope', async () => {
+      // Given
+      const projectDir = join('/', projectExamples.project1.dir);
+      await mkdir(projectDir, { recursive: true });
+      await writeFile('/.env', 'DOTENV_VAR=parentScope');
+      await writeFile('/src.env', 'DOTENV_VAR=from-dot-env');
+
+      // When/Verify
+      await testHelper.testParse(['dotEnvCommand'], [
+        '[Project1] running: echo $DOTENV_VAR',
+        '[Project1] from-dot-env',
+        '[Project1] success: echo $DOTENV_VAR'
+      ]);
     });
 
     test('when unknown command provided should exit with code 21',

--- a/test/cli/RunCommand.spec.ts
+++ b/test/cli/RunCommand.spec.ts
@@ -189,8 +189,6 @@ describe('RunCommand', () => {
       ]);
     });
 
-
-
     test('when multiple .env file exists, should use value from closest scope', async () => {
       // Given
       const projectDir = join('/', projectExamples.project1.dir);

--- a/test/cli/RunCommand.spec.ts
+++ b/test/cli/RunCommand.spec.ts
@@ -195,7 +195,7 @@ describe('RunCommand', () => {
       const projectDir = join('/', projectExamples.project1.dir);
       await mkdir(projectDir, { recursive: true });
       await writeFile('/.env', 'DOTENV_VAR=parentScope');
-      await writeFile('/src.env', 'DOTENV_VAR=from-dot-env');
+      await writeFile('/src/.env', 'DOTENV_VAR=from-dot-env');
 
       // When/Verify
       await testHelper.testParse(['dotEnvCommand'], [

--- a/test/cli/RunCommand.spec.ts
+++ b/test/cli/RunCommand.spec.ts
@@ -9,7 +9,7 @@ import { ProjectService } from '../../src/projects/ProjectService';
 import { TYPES } from '../../src/TYPES';
 import { BaseDirProvider } from '../../src/util/BaseDirProvider';
 import { SpawnService } from '../../src/util/SpawnService';
-import { createContainer, MockBaseDirProvider, MockProjectService, MockSpawnService } from '../mocks';
+import { createContainer, MockBaseDirProvider, MockProjectService, MockSpawnService, resetFs } from '../mocks';
 import { projectExamples } from '../project-examples';
 import { CommandTestHelper } from './CommandTestHelper';
 
@@ -19,7 +19,8 @@ describe('RunCommand', () => {
 
   let projectService: MockProjectService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await resetFs();
     const container = createContainer();
 
     container.rebind<ProjectService>(TYPES.ProjectService).to(MockProjectService).inSingletonScope();

--- a/test/cli/TemplateCommand.spec.ts
+++ b/test/cli/TemplateCommand.spec.ts
@@ -4,7 +4,7 @@ jest.mock('fs/promises');
 import { writeFile } from 'fs/promises';
 import { TemplateCommand } from '../../src/cli/TemplateCommand';
 import { TYPES } from '../../src/TYPES';
-import { createContainer, MockProjectService } from '../mocks';
+import { createContainer, MockProjectService, resetFs } from '../mocks';
 import { projectExamples } from '../project-examples';
 import { CommandTestHelper } from './CommandTestHelper';
 
@@ -14,7 +14,8 @@ describe(TemplateCommand, () => {
 
   let testHelper: CommandTestHelper;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await resetFs();
     const container = createContainer();
 
     container.rebind(TYPES.ProjectService).to(MockProjectService).inSingletonScope();

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -3,7 +3,6 @@ jest.mock('fs/promises');
 
 import 'reflect-metadata';
 
-import { Command } from 'commander';
 import { ChildProcessWithoutNullStreams, spawn, SpawnOptionsWithoutStdio } from 'child_process';
 import { Container, injectable } from 'inversify';
 import { cloneDeep, uniq } from 'lodash';

--- a/test/project-examples.ts
+++ b/test/project-examples.ts
@@ -1,3 +1,4 @@
+import { platform } from 'os';
 import { ProjectWithVersion } from '../src/projects/Project';
 
 export const projectExamples = {
@@ -63,6 +64,13 @@ export const projectExamples = {
       malformedCondition: {
         command: 'exit 42',
         condition: '1 = 2'
+      },
+      dotEnvCommand: {
+        name: 'echo $DOTENV_VAR',
+        command: platform() === 'win32'
+          ? 'echo %DOTENV_VAR%'
+          : 'echo $DOTENV_VAR',
+        shell: platform() === 'win32' ? 'cmd.exe' : true,
       }
     },
     version: {

--- a/test/util/ContextService.spec.ts
+++ b/test/util/ContextService.spec.ts
@@ -84,7 +84,7 @@ describe(ContextServiceImpl, () => {
     test('when expansion from parent .env file should expand correctly', async () => {
       // Given
       await writeFile(join('/', project.dir, '.env'), 'DOTENV_VAR=from-global-scope\nDOTENV_GLOBAL=from-global-env-var\nDOTENV_GLOBAL2=load-child-${DOTENV_BUILD}');
-      await writeFile(join('/', project.dir, '.build.env'), 'DOTENV_VAR=${DOTENV_GLOBAL}\nDOTENV_BUILD=from-build-scope}');
+      await writeFile(join('/', project.dir, '.build.env'), 'DOTENV_VAR=${DOTENV_GLOBAL}\nDOTENV_BUILD=from-build-scope');
 
       // When
       const context = await contextService.getProjectContext(project, 'build');

--- a/test/util/ContextService.spec.ts
+++ b/test/util/ContextService.spec.ts
@@ -25,7 +25,7 @@ describe(ContextServiceImpl, () => {
 
     projectServce.addProjects(...Object.values(projectExamples));
 
-    await mkdir(projectExamples.project1.dir);
+    await mkdir(join('/', projectExamples.project1.dir), { recursive: true });
   });
 
   describe('.env support', () => {
@@ -33,7 +33,7 @@ describe(ContextServiceImpl, () => {
 
     test('when .env file exists should load environment variables', async () => {
       // Given
-      await writeFile(join(project.dir, '.env'), 'DOTENV_VAR=from-dot-env');
+      await writeFile(join('/', project.dir, '.env'), 'DOTENV_VAR=from-dot-env');
 
       // When
       const context = await contextService.getProjectContext(project);
@@ -44,7 +44,7 @@ describe(ContextServiceImpl, () => {
 
     test('when .env file exists in parent directory should load environment variables', async () => {
       // Given
-      await writeFile(join(project.dir, '..', '.env'), 'DOTENV_VAR=from-dot-env');
+      await writeFile(join('/', project.dir, '..', '.env'), 'DOTENV_VAR=from-dot-env');
 
       // When
       const context = await contextService.getProjectContext(project);
@@ -55,8 +55,8 @@ describe(ContextServiceImpl, () => {
 
     test('when multiple .env files exist in parent directories should load environment variables', async () => {
       // Given
-      await writeFile(join(project.dir, '..', '..', '.env'), 'DOTENV_VAR=from-base-dot-env\nDOTENV_BASE=from-base-dot-env');
-      await writeFile(join(project.dir, '..', '.env'), 'DOTENV_VAR=from-dot-env');
+      await writeFile(join('/', project.dir, '..', '..', '.env'), 'DOTENV_VAR=from-base-dot-env\nDOTENV_BASE=from-base-dot-env');
+      await writeFile(join('/', project.dir, '..', '.env'), 'DOTENV_VAR=from-dot-env');
 
       // When
       const context = await contextService.getProjectContext(project);
@@ -68,9 +68,9 @@ describe(ContextServiceImpl, () => {
 
     test('when multiple .env files for different scopes exist in the same directory should load environment variables', async () => {
       // Given
-      await writeFile(join(project.dir, '.env'), 'DOTENV_VAR=from-global-scope\nDOTENV_GLOBAL=from-global-scope');
-      await writeFile(join(project.dir, '.build.env'), 'DOTENV_VAR=from-build-scope\nDOTENV_BUILD=from-build-scope');
-      await writeFile(join(project.dir, '.deploy.env'), 'DOTENV_VAR=from-deploy-scope');
+      await writeFile(join('/', project.dir, '.env'), 'DOTENV_VAR=from-global-scope\nDOTENV_GLOBAL=from-global-scope');
+      await writeFile(join('/', project.dir, '.build.env'), 'DOTENV_VAR=from-build-scope\nDOTENV_BUILD=from-build-scope');
+      await writeFile(join('/', project.dir, '.deploy.env'), 'DOTENV_VAR=from-deploy-scope');
 
       // When
       const context = await contextService.getProjectContext(project, 'build');
@@ -83,8 +83,8 @@ describe(ContextServiceImpl, () => {
 
     test('when expansion from parent .env file should expand correctly', async () => {
       // Given
-      await writeFile(join(project.dir, '.env'), 'DOTENV_VAR=from-global-scope\nDOTENV_GLOBAL=from-global-env-var\nDOTENV_GLOBAL2=load-child-${DOTENV_BUILD}');
-      await writeFile(join(project.dir, '.build.env'), 'DOTENV_VAR=${DOTENV_GLOBAL}\nDOTENV_BUILD=from-build-scope}');
+      await writeFile(join('/', project.dir, '.env'), 'DOTENV_VAR=from-global-scope\nDOTENV_GLOBAL=from-global-env-var\nDOTENV_GLOBAL2=load-child-${DOTENV_BUILD}');
+      await writeFile(join('/', project.dir, '.build.env'), 'DOTENV_VAR=${DOTENV_GLOBAL}\nDOTENV_BUILD=from-build-scope}');
 
       // When
       const context = await contextService.getProjectContext(project, 'build');

--- a/test/util/ContextService.spec.ts
+++ b/test/util/ContextService.spec.ts
@@ -1,0 +1,97 @@
+jest.mock('fs');
+jest.mock('fs/promises');
+
+import { mkdir, writeFile } from 'fs/promises';
+import { Container } from 'inversify';
+import { join } from 'path';
+import { TYPES } from '../../src/TYPES';
+import { ContextServiceImpl } from '../../src/util/ContextService';
+import { createContainer, MockProjectService, resetFs } from '../mocks';
+import { projectExamples } from '../project-examples';
+
+describe(ContextServiceImpl, () => {
+  let container: Container;
+  let contextService: ContextServiceImpl;
+  let projectServce: MockProjectService;
+
+  beforeEach(async () => {
+    await resetFs();
+    container = createContainer();
+
+    container.rebind(TYPES.ProjectService).to(MockProjectService).inSingletonScope();
+
+    contextService = container.get(TYPES.ContextService);
+    projectServce = container.get(TYPES.ProjectService);
+
+    projectServce.addProjects(...Object.values(projectExamples));
+
+    await mkdir(projectExamples.project1.dir);
+  });
+
+  describe('.env support', () => {
+    const project = projectExamples.project1;
+
+    test('when .env file exists should load environment variables', async () => {
+      // Given
+      await writeFile(join(project.dir, '.env'), 'DOTENV_VAR=from-dot-env');
+
+      // When
+      const context = await contextService.getProjectContext(project);
+
+      // Verify
+      expect(context.env.DOTENV_VAR).toBe('from-dot-env');
+    });
+
+    test('when .env file exists in parent directory should load environment variables', async () => {
+      // Given
+      await writeFile(join(project.dir, '..', '.env'), 'DOTENV_VAR=from-dot-env');
+
+      // When
+      const context = await contextService.getProjectContext(project);
+
+      // Verify
+      expect(context.env.DOTENV_VAR).toBe('from-dot-env');
+    });
+
+    test('when multiple .env files exist in parent directories should load environment variables', async () => {
+      // Given
+      await writeFile(join(project.dir, '..', '..', '.env'), 'DOTENV_VAR=from-base-dot-env\nDOTENV_BASE=from-base-dot-env');
+      await writeFile(join(project.dir, '..', '.env'), 'DOTENV_VAR=from-dot-env');
+
+      // When
+      const context = await contextService.getProjectContext(project);
+
+      // Verify
+      expect(context.env.DOTENV_VAR).toBe('from-dot-env');
+      expect(context.env.DOTENV_BASE).toBe('from-base-dot-env');
+    });
+
+    test('when multiple .env files for different scopes exist in the same directory should load environment variables', async () => {
+      // Given
+      await writeFile(join(project.dir, '.env'), 'DOTENV_VAR=from-global-scope\nDOTENV_GLOBAL=from-global-scope');
+      await writeFile(join(project.dir, '.build.env'), 'DOTENV_VAR=from-build-scope\nDOTENV_BUILD=from-build-scope');
+      await writeFile(join(project.dir, '.deploy.env'), 'DOTENV_VAR=from-deploy-scope');
+
+      // When
+      const context = await contextService.getProjectContext(project, 'build');
+
+      // Verify
+      expect(context.env.DOTENV_VAR).toBe('from-build-scope');
+      expect(context.env.DOTENV_GLOBAL).toBe('from-global-scope');
+      expect(context.env.DOTENV_BUILD).toBe('from-build-scope');
+    });
+
+    test('when expansion from parent .env file should expand correctly', async () => {
+      // Given
+      await writeFile(join(project.dir, '.env'), 'DOTENV_VAR=from-global-scope\nDOTENV_GLOBAL=from-global-env-var\nDOTENV_GLOBAL2=load-child-${DOTENV_BUILD}');
+      await writeFile(join(project.dir, '.build.env'), 'DOTENV_VAR=${DOTENV_GLOBAL}\nDOTENV_BUILD=from-build-scope}');
+
+      // When
+      const context = await contextService.getProjectContext(project, 'build');
+
+      // Verify
+      expect(context.env.DOTENV_VAR).toBe('from-global-env-var');
+      expect(context.env.DOTENV_GLOBAL2).toBe('load-child-from-build-scope');
+    });
+  });
+});

--- a/test/util/ContextService.spec.ts
+++ b/test/util/ContextService.spec.ts
@@ -93,5 +93,16 @@ describe(ContextServiceImpl, () => {
       expect(context.env.DOTENV_VAR).toBe('from-global-env-var');
       expect(context.env.DOTENV_GLOBAL2).toBe('load-child-from-build-scope');
     });
+
+    test('when expansion using project variable should expand correctly', async () => {
+      // Given
+      await writeFile(join('/', project.dir, '.env'), 'DOTENV_VAR=${PROJECT_VERSION}');
+
+      // When
+      const context = await contextService.getProjectContext(project);
+
+      // Verify
+      expect(context.env.DOTENV_VAR).toBe(project.version.hash);
+    });
   });
 });

--- a/test/util/EvalService.spec.ts
+++ b/test/util/EvalService.spec.ts
@@ -2,6 +2,7 @@ jest.mock('fs');
 jest.mock('fs/promises');
 
 import { Container } from 'inversify';
+import { Context, ContextService } from '../../src/projects/ContextService';
 import { ProjectCommandStatus } from '../../src/projects/ProjectCommandStatus';
 import { TYPES } from '../../src/TYPES';
 import { EvalServiceImpl } from '../../src/util/EvalService';
@@ -12,8 +13,9 @@ describe('EvalService', () => {
   let container: Container;
   let evalService: EvalServiceImpl;
   let projectService: MockProjectService;
+  let contextService: ContextService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     container = createContainer();
 
     container.rebind(TYPES.EvalService).to(EvalServiceImpl).inSingletonScope();
@@ -21,6 +23,7 @@ describe('EvalService', () => {
 
     evalService = container.get(TYPES.EvalService);
     projectService = container.get(TYPES.ProjectService);
+    contextService = container.get(TYPES.ContextService);
   });
 
   test('should be resolvable and singleton', () => {
@@ -37,96 +40,76 @@ describe('EvalService', () => {
   });
 
   describe('.safeEval()', () => {
-    test('when prepareContext not called should throw error', () => {
-      expect(
-        () => evalService.safeEval('1+1')
-      ).toThrowError('Must call .prepareContext() first');
-    });
-
     test('should be able to eval simple arithmetic', async () => {
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEval('1 + 1')).toBe(2);
+      expect(evalService.safeEval('1 + 1', context)).toBe(2);
     });
 
     test('should be able to eval context os property', async () => {
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEval('os')).toBe(process.platform);
+      expect(evalService.safeEval('os', context)).toBe(process.platform);
     });
 
     test('should be able to eval context projects property', async () => {
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEval('projects')).toEqual(evalService.context.projects);
+      expect(evalService.safeEval('projects', context)).toEqual(context.projects);
     });
 
     test('should be able to eval context projects nested property', async () => {
       projectService.addProject(projectExamples.project1);
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEval('projects.Project1.dir')).toEqual(projectExamples.project1.dir);
+      expect(evalService.safeEval('projects.Project1.dir', context)).toEqual(projectExamples.project1.dir);
     });
 
     test('should be able to eval project command status', async () => {
-      await evalService.prepareContext();
-      evalService.amendContext({
-        status: {
-          'Project1': ProjectCommandStatus.failed,
-        }
-      });
+      contextService.setProjectStatus(projectExamples.project1, ProjectCommandStatus.failed);
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEval('status.Project1')).toBe(ProjectCommandStatus.failed);
+      expect(evalService.safeEval('status.Project1', context)).toBe(ProjectCommandStatus.failed);
     });
   });
 
   describe('.safeEvalTemplate()', () => {
-    test('when prepareContext not called should throw error', () => {
-      expect(
-        () => evalService.safeEvalTemplate('${{1+1}}')
-      ).toThrowError('Must call .prepareContext() first');
-    });
-
     test('should be able to eval simple arithmetic', async () => {
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEvalTemplate('${{1 + 1}}')).toBe('2');
+      expect(evalService.safeEvalTemplate('${{1 + 1}}', context)).toBe('2');
     });
 
     test('should be able to eval context os property', async () => {
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEvalTemplate('${{os}}')).toBe(process.platform);
+      expect(evalService.safeEvalTemplate('${{os}}', context)).toBe(process.platform);
     });
 
     test('should be able to eval context projects property', async () => {
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEvalTemplate('${{Object.keys(projects)}}')).toEqual(`${Object.keys(evalService.context.projects)}`);
+      expect(evalService.safeEvalTemplate('${{Object.keys(projects)}}', context)).toEqual(`${Object.keys(context.projects)}`);
     });
 
     test('should be able to eval context projects nested property', async () => {
       projectService.addProject(projectExamples.project1);
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEvalTemplate('${{projects.Project1.dir}}')).toEqual(projectExamples.project1.dir);
+      expect(evalService.safeEvalTemplate('${{projects.Project1.dir}}', context)).toEqual(projectExamples.project1.dir);
     });
 
     test('should be able to eval project command status', async () => {
-      await evalService.prepareContext();
-      evalService.amendContext({
-        status: {
-          'Project1': ProjectCommandStatus.failed,
-        }
-      });
+      contextService.setProjectStatus(projectExamples.project1, ProjectCommandStatus.failed);
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEvalTemplate('${{status.Project1}}')).toBe(ProjectCommandStatus.failed);
+      expect(evalService.safeEvalTemplate('${{status.Project1}}', context)).toBe(ProjectCommandStatus.failed);
     });
 
     test('should be able to eval multiple replacements', async () => {
-      await evalService.prepareContext();
+      const context = await contextService.getContext();
 
-      expect(evalService.safeEvalTemplate('`${{1}} + ${{2}} = ${{1+2}}`')).toBe('`1 + 2 = 3`');
+      expect(evalService.safeEvalTemplate('`${{1}} + ${{2}} = ${{1+2}}`', context)).toBe('`1 + 2 = 3`');
     });
   });
 });

--- a/test/util/EvalService.spec.ts
+++ b/test/util/EvalService.spec.ts
@@ -2,11 +2,11 @@ jest.mock('fs');
 jest.mock('fs/promises');
 
 import { Container } from 'inversify';
-import { Context, ContextService } from '../../src/util/ContextService';
+import { ContextService } from '../../src/util/ContextService';
 import { ProjectCommandStatus } from '../../src/projects/ProjectCommandStatus';
 import { TYPES } from '../../src/TYPES';
 import { EvalServiceImpl } from '../../src/util/EvalService';
-import { createContainer, MockProjectService } from '../mocks';
+import { createContainer, MockProjectService, resetFs } from '../mocks';
 import { projectExamples } from '../project-examples';
 
 describe('EvalService', () => {
@@ -16,6 +16,7 @@ describe('EvalService', () => {
   let contextService: ContextService;
 
   beforeEach(async () => {
+    await resetFs();
     container = createContainer();
 
     container.rebind(TYPES.EvalService).to(EvalServiceImpl).inSingletonScope();

--- a/test/util/EvalService.spec.ts
+++ b/test/util/EvalService.spec.ts
@@ -2,7 +2,7 @@ jest.mock('fs');
 jest.mock('fs/promises');
 
 import { Container } from 'inversify';
-import { Context, ContextService } from '../../src/projects/ContextService';
+import { Context, ContextService } from '../../src/util/ContextService';
 import { ProjectCommandStatus } from '../../src/projects/ProjectCommandStatus';
 import { TYPES } from '../../src/TYPES';
 import { EvalServiceImpl } from '../../src/util/EvalService';


### PR DESCRIPTION
* `.env` files can be loaded from parent directories
* `.[commandName].env` files can override `.env` files for specific commands
* Variable expansion can be used to require variables to be defined in projects