### PR TITLE
Replace safe-eval with vm2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "build-champ",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "build-champ",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -19,8 +19,8 @@
         "minimatch": "^5.1.6",
         "p-queue": "^6.6.2",
         "reflect-metadata": "^0.1.13",
-        "safe-eval": "^0.4.1",
         "simple-git": "^3.19.0",
+        "vm2": "^3.9.19",
         "xml-js": "^1.6.11",
         "yaml": "^2.3.1"
       },
@@ -2111,7 +2111,6 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2132,7 +2131,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5067,11 +5065,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-eval": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/safe-eval/-/safe-eval-0.4.1.tgz",
-      "integrity": "sha512-wmiu4RSYVZ690RP1+cv/LxfPK1dIlEN35aW7iv4SMYdqDrHbkll4+NJcHmKm7PbCuI1df1otOcPwgcc2iFR85g=="
-    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -5627,6 +5620,21 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
+    },
+    "node_modules/vm2": {
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -7278,8 +7286,7 @@
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -7291,8 +7298,7 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -9466,11 +9472,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "safe-eval": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/safe-eval/-/safe-eval-0.4.1.tgz",
-      "integrity": "sha512-wmiu4RSYVZ690RP1+cv/LxfPK1dIlEN35aW7iv4SMYdqDrHbkll4+NJcHmKm7PbCuI1df1otOcPwgcc2iFR85g=="
-    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -9852,6 +9853,15 @@
           "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
           "dev": true
         }
+      }
+    },
+    "vm2": {
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "minimatch": "^5.1.6",
     "p-queue": "^6.6.2",
     "reflect-metadata": "^0.1.13",
-    "safe-eval": "^0.4.1",
     "simple-git": "^3.19.0",
+    "vm2": "^3.9.19",
     "xml-js": "^1.6.11",
     "yaml": "^2.3.1"
   }

--- a/src/services/EvalService.ts
+++ b/src/services/EvalService.ts
@@ -30,6 +30,7 @@ export class EvalServiceImpl implements EvalService {
   safeEval<T extends Context>(code: string, context: T): unknown {
     const vm = new VM({
       sandbox: context,
+      eval: false,
     });
 
     return vm.run(code);

--- a/src/services/EvalService.ts
+++ b/src/services/EvalService.ts
@@ -1,6 +1,6 @@
 import { injectable } from 'inversify';
 import 'reflect-metadata';
-import safeEval from 'safe-eval';
+import { VM } from 'vm2';
 import { Context } from './ContextService';
 
 export interface EvalService {
@@ -28,6 +28,10 @@ export class EvalServiceImpl implements EvalService {
   }
 
   safeEval<T extends Context>(code: string, context: T): unknown {
-    return safeEval(code, context);
+    const vm = new VM({
+      sandbox: context,
+    });
+
+    return vm.run(code);
   }
 }

--- a/test/__mocks__/fs.ts
+++ b/test/__mocks__/fs.ts
@@ -1,3 +1,17 @@
 import { fs } from 'memfs';
+import { dirname, join } from 'path';
+
+const fsReal = jest.requireActual('fs') as typeof fs;
+const copyFiles = [
+  'node_modules/vm2/lib/bridge.js',
+  'node_modules/vm2/lib/setup-sandbox.js',
+];
+
+for (const file of copyFiles) {
+  const path = join(process.cwd(), file);
+  const content = fsReal.readFileSync(path, 'utf8');
+  fs.mkdirSync(dirname(path), { recursive: true });
+  fs.writeFileSync(path, content);
+}
 
 module.exports = fs;


### PR DESCRIPTION
`safe-eval` has not had updates in some time now, so replacing it with `vm2` (also removes the vulnerability reports 🙂)